### PR TITLE
feat: make the crate `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ keywords = ["cassowary", "layout", "tui", "solver"]
 categories = ["algorithms", "command-line-interface", "graphics", "gui", "rendering"]
 
 [dependencies]
+hashbrown = "0.15.2"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 rstest = "0.23.0"
-thiserror = "1.0.64"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 fastrand = "2.1.1"

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,7 +1,7 @@
-use std::{
+use alloc::sync::Arc;
+use core::{
     hash::{Hash, Hasher},
     ops,
-    sync::Arc,
 };
 
 use crate::{Expression, RelationalOperator, Strength, Term, Variable, WeightedRelation};
@@ -53,15 +53,15 @@ impl Constraint {
 
 impl Hash for Constraint {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
-        use std::ops::Deref;
+        use core::ops::Deref;
         hasher.write_usize(self.inner.deref() as *const _ as usize);
     }
 }
 
 impl PartialEq for Constraint {
     fn eq(&self, other: &Constraint) -> bool {
-        use std::ops::Deref;
-        std::ptr::eq(self.inner.deref(), other.inner.deref())
+        use core::ops::Deref;
+        core::ptr::eq(self.inner.deref(), other.inner.deref())
     }
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,4 +1,5 @@
-use std::ops;
+use alloc::{vec, vec::Vec};
+use core::ops;
 
 use crate::{Term, Variable};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! self-explanatory):
 //!
 //! ```ignore
-//! use std::collections::HashMap;
+//! use hashbrown::HashMap;
 //! let mut names = HashMap::new();
 //! fn print_changes(names: &HashMap<Variable, &'static str>, changes: &[(Variable, f64)]) {
 //!     println!("Changes:");
@@ -167,7 +167,7 @@
 //! # use kasuari::{ Solver, Variable, Strength };
 //! # use kasuari::WeightedRelation::*;
 //! #
-//! # use std::collections::HashMap;
+//! # use hashbrown::HashMap;
 //! # let mut names = HashMap::new();
 //! # fn print_changes(names: &HashMap<Variable, &'static str>, changes: &[(Variable, f64)]) {
 //! #     println!("Changes:");
@@ -232,6 +232,9 @@
 //! not have any inherent knowledge of user interfaces, directions or boxes. Thus for use in a user
 //! interface this crate should ideally be wrapped by a higher level API, which is outside the scope
 //! of this crate.
+
+#![no_std]
+extern crate alloc;
 
 mod constraint;
 mod error;

--- a/src/relations.rs
+++ b/src/relations.rs
@@ -1,4 +1,4 @@
-use std::{fmt, ops};
+use core::{fmt, ops};
 
 use crate::{Expression, PartialConstraint, Strength, Term, Variable};
 

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map::Entry, HashMap};
+use hashbrown::{hash_map::Entry, HashMap};
 
 #[derive(Debug, Clone)]
 pub struct Row {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,9 +1,6 @@
-use std::{
-    cell::RefCell,
-    collections::{hash_map::Entry, HashMap, HashSet},
-    f64,
-    rc::Rc,
-};
+use alloc::{boxed::Box, rc::Rc, vec::Vec};
+use core::{cell::RefCell, f64};
+use hashbrown::{hash_map::Entry, HashMap, HashSet};
 
 use crate::{
     constraint::Constraint,

--- a/src/strength.rs
+++ b/src/strength.rs
@@ -65,7 +65,7 @@ impl Strength {
     }
 }
 
-impl std::ops::Add<Strength> for Strength {
+impl core::ops::Add<Strength> for Strength {
     type Output = Strength;
 
     /// Add two strengths together, clipping the result to the legal range
@@ -75,7 +75,7 @@ impl std::ops::Add<Strength> for Strength {
     }
 }
 
-impl std::ops::Sub<Strength> for Strength {
+impl core::ops::Sub<Strength> for Strength {
     type Output = Strength;
 
     /// Subtract one strength from another, clipping the result to the legal range
@@ -85,7 +85,7 @@ impl std::ops::Sub<Strength> for Strength {
     }
 }
 
-impl std::ops::AddAssign<Strength> for Strength {
+impl core::ops::AddAssign<Strength> for Strength {
     /// Perform an in-place addition of two strengths, clipping the result to the legal range
     #[inline]
     fn add_assign(&mut self, rhs: Strength) {
@@ -93,7 +93,7 @@ impl std::ops::AddAssign<Strength> for Strength {
     }
 }
 
-impl std::ops::SubAssign<Strength> for Strength {
+impl core::ops::SubAssign<Strength> for Strength {
     /// Perform an in-place subtraction of two strengths, clipping the result to the legal range
     #[inline]
     fn sub_assign(&mut self, rhs: Strength) {
@@ -101,7 +101,7 @@ impl std::ops::SubAssign<Strength> for Strength {
     }
 }
 
-impl std::ops::Mul<f64> for Strength {
+impl core::ops::Mul<f64> for Strength {
     type Output = Strength;
 
     /// Multiply a strength by a scalar, clipping the result to the legal range
@@ -111,7 +111,7 @@ impl std::ops::Mul<f64> for Strength {
     }
 }
 
-impl std::ops::Mul<Strength> for f64 {
+impl core::ops::Mul<Strength> for f64 {
     type Output = Strength;
 
     /// Multiply a scalar by a strength, clipping the result to the legal range
@@ -121,7 +121,7 @@ impl std::ops::Mul<Strength> for f64 {
     }
 }
 
-impl std::ops::MulAssign<f64> for Strength {
+impl core::ops::MulAssign<f64> for Strength {
     /// Perform an in-place multiplication of a strength by a scalar, clipping the result to the
     /// legal range
     #[inline]
@@ -130,21 +130,21 @@ impl std::ops::MulAssign<f64> for Strength {
     }
 }
 
-impl std::cmp::Ord for Strength {
+impl core::cmp::Ord for Strength {
     #[inline]
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.partial_cmp(&other.0).unwrap()
     }
 }
 
-impl std::cmp::PartialOrd for Strength {
+impl core::cmp::PartialOrd for Strength {
     #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl std::cmp::Eq for Strength {}
+impl core::cmp::Eq for Strength {}
 
 #[cfg(test)]
 mod tests {

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,4 +1,5 @@
-use std::ops;
+use alloc::vec;
+use core::ops;
 
 use crate::{Expression, Variable};
 

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     ops,
     sync::atomic::{AtomicUsize, Ordering},
 };
@@ -274,6 +274,7 @@ impl ops::Div<f32> for Variable {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     const LEFT: Variable = Variable(0);
     const RIGHT: Variable = Variable(1);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,8 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::rc::Rc;
+extern crate alloc;
+
+use alloc::rc::Rc;
+use core::cell::RefCell;
+use hashbrown::HashMap;
 
 use kasuari::Variable;
 


### PR DESCRIPTION
- bumped `thiserror`, as it is `no_std` only since v2, seems like no additional changes are needed
- added `hashbrown` for `HashMap` replacement

CI will fail (it fails on main), but I guess we should fix that in separate PR.