### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ratatui/kasuari/security/code-scanning/1](https://github.com/ratatui/kasuari/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
- The `ci`, `clippy`, and `fmt` jobs only need `contents: read` to access the repository's code.
- The `coverage` job uses the `codecov/codecov-action`, which may require `contents: read` and potentially `security-events: read` for code scanning or coverage reporting.

The `permissions` block can be added at the root level to apply to all jobs, or it can be added to each job individually for finer control.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
