### PR TITLE
Use portable-atomic to allow use on targets without atomic instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,13 @@ default = ["std"]
 
 ## enables std
 std = ["thiserror/std"]
+## use portable-atomic to polyfill CAS atomics on targets that do not have them
+portable-atomic = ["dep:portable-atomic", "dep:portable-atomic-util"]
 
 [dependencies]
 hashbrown = "0.15"
-portable-atomic = "1.11"
-portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
+portable-atomic = { version = "1.11", optional = true }
+portable-atomic-util = { version = "0.2.4", features = ["alloc"], optional = true }
 thiserror = { version = "2.0", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ portable-atomic = ["dep:portable-atomic", "dep:portable-atomic-util"]
 
 [dependencies]
 hashbrown = "0.15"
-portable-atomic = { version = "1.11", optional = true }
+portable-atomic = { version = "1.11",  default-features = false, features = ["require-cas"], optional = true }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"], optional = true }
 thiserror = { version = "2.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ std = ["thiserror/std"]
 
 [dependencies]
 hashbrown = "0.15"
-portable-atomic = "1.11.1"
+portable-atomic = "1.11"
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 thiserror = { version = "2.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ std = ["thiserror/std"]
 
 [dependencies]
 hashbrown = "0.15"
+portable-atomic = "1.11.1"
+portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 thiserror = { version = "2.0", default-features = false }
 
 [dev-dependencies]

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -2,6 +2,7 @@
 use alloc::sync::Arc;
 use core::hash::{Hash, Hasher};
 use core::ops;
+
 #[cfg(feature = "portable-atomic")]
 use portable_atomic_util::Arc;
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,4 +1,4 @@
-use alloc::sync::Arc;
+use portable_atomic_util::Arc;
 use core::hash::{Hash, Hasher};
 use core::ops;
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,10 +1,9 @@
-
 #[cfg(not(feature = "portable-atomic"))]
 use alloc::sync::Arc;
-#[cfg(feature = "portable-atomic")]
-use portable_atomic_util::Arc;
 use core::hash::{Hash, Hasher};
 use core::ops;
+#[cfg(feature = "portable-atomic")]
+use portable_atomic_util::Arc;
 
 use crate::{Expression, RelationalOperator, Strength, Term, Variable, WeightedRelation};
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,3 +1,7 @@
+
+#[cfg(not(feature = "portable-atomic"))]
+use alloc::sync::Arc;
+#[cfg(feature = "portable-atomic")]
 use portable_atomic_util::Arc;
 use core::hash::{Hash, Hasher};
 use core::ops;

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,6 +1,7 @@
 use core::ops;
 #[cfg(not(feature = "portable-atomic"))]
 use core::sync::atomic::{AtomicUsize, Ordering};
+
 #[cfg(feature = "portable-atomic")]
 use portable_atomic::{AtomicUsize, Ordering};
 

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,5 +1,5 @@
 use core::ops;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use portable_atomic::{AtomicUsize, Ordering};
 
 use crate::{Expression, Term};
 

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,4 +1,7 @@
 use core::ops;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "portable-atomic")]
 use portable_atomic::{AtomicUsize, Ordering};
 
 use crate::{Expression, Term};


### PR DESCRIPTION
Some targets do not natively support atomics (eg rp2040, esp32-c3).
By adding portable-atomic, these targets can select a method to emulate atomics.

It might be nice to make this a feature instead to avoid forcing it on for everyone.
Happy to get some feedback on this.