### PR TITLE
Fixed a bug that lead to the leaking of `Symbol`s in the objective function.

### DIFF
--- a/src/solver.rs
+++ b/src/solver.rs
@@ -781,7 +781,8 @@ impl Solver {
     fn remove_constraint_effects(&mut self, constraint: &Constraint, tag: &Tag) {
         if tag.marker.kind() == SymbolKind::Error {
             self.remove_marker_effects(tag.marker, constraint.strength().value());
-        } else if tag.other.kind() == SymbolKind::Error {
+        }
+        if tag.other.kind() == SymbolKind::Error {
             self.remove_marker_effects(tag.other, constraint.strength().value());
         }
     }


### PR DESCRIPTION
Prior to this fix, whenever an `EQ` constraint was added, after being removed, it would always lead to a lingering Symbol on the `objective`.

This was caused by a single `else` keyword, which prevented both `Error` `Symbol`s from being removed, even though neither would be needed anymore.

I noticed this bug when I tried to repeatedly add and remove `Constraint`s from the `Solver` over and over again, and I noticed through debugging that, although every other member of the `Solver` kept a steady size, the `objective` just seemed to keep growing no matter what.

This was caused by an assymetry when removing `Error` `Symbol`s from `EQ` constraints. This PR fixes this assimetry.

I would appreciate if this could be merged and a new version of `kasuari` could be created, so I don't have to post my own on `crates.io`